### PR TITLE
Fix the calculation for the updated belief

### DIFF
--- a/_tutorials/0_Introduction.md
+++ b/_tutorials/0_Introduction.md
@@ -200,7 +200,8 @@ Now we can build our plot:
 # Compute the posterior distribution in closed-form.
 N = length(data)
 heads = sum(data)
-updated_belief = Beta(prior_belief.α + heads, prior_belief.β + N - heads)
+tails = N - heads
+updated_belief = Beta(prior_belief.α + tails, prior_belief.β + heads)
 
 # Visualize a blue density plot of the approximate posterior distribution using HMC (see Chain 1 in the legend).
 p = plot(p_summary, seriestype = :density, xlim = (0,1), legend = :best, w = 2, c = :blue)


### PR DESCRIPTION
The order was reversed as could be seen by computing the posterior distribution for one heads or one tails.
For example, if you calculated the posterior for a sample of size one and containing one heads, the posterior plot would show that the parameter is most likely to be `0` whereas the plot shows that an higher value means a higher probability for heads.