### PR TITLE
Switch to artifacts branch

### DIFF
--- a/make-utils.jl
+++ b/make-utils.jl
@@ -1,5 +1,5 @@
 using Base64, Pkg
-Pkg.develop(url="https://github.com/TuringLang/TuringTutorials")
+Pkg.add(url="https://github.com/TuringLang/TuringTutorials", rev="artifacts")
 using TuringTutorials
 
 ## Text Utilities


### PR DESCRIPTION
Related to https://github.com/TuringLang/TuringTutorials/pull/123.

I've manually compared the Markdown files in https://github.com/TuringLang/TuringTutorials/tree/artifacts to https://turing.ml. I noticed small differences in 08 (multinomial logistic regression). Also, 04 (hidden Markov model) isn't right. This seems to be the same problem as https://github.com/TuringLang/TuringTutorials/issues/114. Apart from that, it all looks good imo.