### PR TITLE
Fix wrong indentation

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -131,7 +131,7 @@ support:
       <div class="col-sm-6  col-md-4 col-xl-4">
         <div class="archive__item-teaser">
           <div class="archive__snippet">
-            {% highlight julia %} {{page.code-sample.snippet}} {% endhighlight %}
+            {% highlight julia %}{{page.code-sample.snippet}}{% endhighlight %}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Hopefully this will remove the extera space before our model macro:
![image](https://user-images.githubusercontent.com/5985769/154165713-19eafda6-21f7-4019-9055-e91fe61c3415.png)
