### PR TITLE
Move to Buildkite output

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -33,8 +33,6 @@ jobs:
             Pkg.develop("Turing")
             Pkg.instantiate()
             Pkg.update()'
-      - echo ${{ env.GITHUB_EVENT_NAME }}
-      - exit 1
       - name: Build and deploy (master)
         run: |
           julia --project=docs --color=yes make.jl

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -33,6 +33,8 @@ jobs:
             Pkg.develop("Turing")
             Pkg.instantiate()
             Pkg.update()'
+      - echo ${{ env.GITHUB_EVENT_NAME }}
+      - exit 1
       - name: Build and deploy (master)
         run: |
           julia --project=docs --color=yes make.jl

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -6,7 +6,9 @@ on:
       - 'master'
     tags: '*'
   workflow_dispatch:
-  pull_request:
+  # With the current deploy config in make.jl, PRs will trigger a deploy!
+  # So, don't enable this without fixing that first.
+  # pull_request:
   schedule:
     # Run on the 23rd hour every day
     - cron:  '0 23 * * *'

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -6,6 +6,7 @@ on:
       - 'master'
     tags: '*'
   workflow_dispatch:
+  pull_request:
   schedule:
     # Run on the 23rd hour every day
     - cron:  '0 23 * * *'

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _site/
 .jekyll-metadata
 .gems
 Manifest.toml
+TuringTutorialsOutput/

--- a/make-utils.jl
+++ b/make-utils.jl
@@ -1,6 +1,9 @@
-using Base64, Pkg
+using Base64
+using LibGit2
+using Pkg
+
 const OUTPUT_DIR = "TuringTutorialsOutput"
-run(`git clone --depth=1 https://github.com/TuringLang/TuringTutorialsOutput $OUTPUT_DIR`)
+clone("https://github.com/TuringLang/TuringTutorialsOutput", OUTPUT_DIR)
 
 ## Text Utilities
 

--- a/make-utils.jl
+++ b/make-utils.jl
@@ -1,6 +1,6 @@
 using Base64, Pkg
-Pkg.add(url="https://github.com/TuringLang/TuringTutorials", rev="artifacts")
-using TuringTutorials
+const OUTPUT_DIR = "TuringTutorialsOutput"
+run(`git clone --depth=1 https://github.com/TuringLang/TuringTutorialsOutput $OUTPUT_DIR`)
 
 ## Text Utilities
 
@@ -270,8 +270,7 @@ function copy_tutorial(tutorial_dest_path)
     tmp_path = tempname()
     mkdir(tmp_path)
 
-    # Get the path of `TuringTutorials`
-    md_path = joinpath(dirname(pathof(TuringTutorials)), "..", "markdown")
+    md_path = joinpath(OUTPUT_DIR, "markdown")
 
     # Copy the .md versions of all examples.
     try

--- a/make-utils.jl
+++ b/make-utils.jl
@@ -309,6 +309,8 @@ function copy_tutorial(tutorial_dest_path)
     finally
         # Clean up temporary workspace
         rm(tmp_path, recursive=true)
+
+        rm(OUTPUT_DIR, recursive=true)
     end
 end
 

--- a/make.jl
+++ b/make.jl
@@ -101,12 +101,6 @@ cp(joinpath(tmp_path, "assets"), joinpath(tmp_path, "_site", "assets"), force=tr
 
 repo = "github.com:TuringLang/turing.ml.git"
 
-deploy_config = GitHubActions(
-    "TuringLang/turing.ml", #github_repository::String
-    "push", #github_event_name::String
-    is_dev ? "refs/heads/master" : "refs/tags/$(ARGS[1])" #github_ref::String
-)
-
 deploydocs(
     target = joinpath(tmp_path, "_site"),
     repo = repo,

--- a/make.jl
+++ b/make.jl
@@ -113,8 +113,7 @@ deploydocs(
     branch = "gh-pages",
     devbranch = "master",
     devurl = "dev",
-    versions = ["stable" => "v^", "v#.#", "dev" => "dev"],
-    deploy_config = deploy_config
+    versions = ["stable" => "v^", "v#.#", "dev" => "dev"]
 )
 
 @info "" get(ENV, "GITHUB_REF", missing)

--- a/make.jl
+++ b/make.jl
@@ -101,13 +101,20 @@ cp(joinpath(tmp_path, "assets"), joinpath(tmp_path, "_site", "assets"), force=tr
 
 repo = "github.com:TuringLang/turing.ml.git"
 
+deploy_config = GitHubActions(
+    "TuringLang/turing.ml", #github_repository::String
+    "push", #github_event_name::String
+    is_dev ? "refs/heads/master" : "refs/tags/$(ARGS[1])" #github_ref::String
+)
+
 deploydocs(
     target = joinpath(tmp_path, "_site"),
     repo = repo,
     branch = "gh-pages",
     devbranch = "master",
     devurl = "dev",
-    versions = ["stable" => "v^", "v#.#", "dev" => "dev"]
+    versions = ["stable" => "v^", "v#.#", "dev" => "dev"],
+    deploy_config = deploy_config
 )
 
 @info "" get(ENV, "GITHUB_REF", missing)


### PR DESCRIPTION
This PR switches to Buildkite outputs.

Also, ensures that pull requests are **not** deployed.