### PR TITLE
Create TuringElect

### DIFF
--- a/_posts/2022-05-07-gsoc.md
+++ b/_posts/2022-05-07-gsoc.md
@@ -1,0 +1,28 @@
+---
+title: "Introducing TuringElect"
+author: Carlos Parada and the TuringLang team
+date: 2022-05-07
+---
+
+The team behind the Turing probabilistic programming language is proud to announce TuringElect, a new project to build Bayesian forecasts for the 2022 midterms.
+
+We are looking for a media partner interested in purchasing exclusive publishing rights for TuringElect content. We will provide: 
+- Election forecasts taking advantage of the newest innovations in political science and statistical modeling
+- Intuitive explanations of how our model works for lay audiences
+- Interactive web applications to help users understand how our model works
+- Graphics providing easy-to-understand depictions of possible election results
+- Access to our team for model interpretation and consultation
+
+Ultimately, we expect a finished product similar to those put out by [The Economist](https://projects.economist.com/us-2020-forecast/president) or [FiveThirtyEight](https://projects.fivethirtyeight.com/2020-election-forecast/). 
+
+These projects have generated huge volumes of traffic, thanks to their innovative, data-driven approach to reporting: FiveThirtyEight shattered records in 2016 with over [16 million new unique viewers](https://espnpressroom.com/us/press-releases/2016/11/fivethirtyeight-sets-traffic-records-election-day-night/), more than the NBA finals or the average MLB World Series game. Our model can drive similarly high levels of traffic to your site, including many repeat customers in key demographic segments interested in data-based approaches, such as younger and college-educated readers. Supporting such a project would also help build a reputation for informative, data-driven journalism: Modern outlets are racing to hire statisticians, as in The Economist’s [prior successful partnership](https://projects.economist.com/us-2020-forecast/president) with researchers at Columbia University.
+
+Why Turing?
+
+Turing.jl is a world-class probabilistic programming language (PPL) that allows users to specify complex models in only a few lines of code. It is the first truly universal PPL capable of expressing any Bayesian model elegantly, and its innovative new design allows for [blazing fast inference](https://arxiv.org/abs/2002.02702) with [state-of-the-art algorithms](http://proceedings.mlr.press/v118/xu20a.htm). All this makes it the tool of choice for new scientists and [Nobel Laureates](http://www.tomsargent.com/research/Yield_Curve.pdf) alike.
+
+The Turing team brings together researchers from top-tier institutions including Cambridge, Oxford, and the University of New South Wales, working alongside industry professionals in machine learning. Our team has experience in a wide variety of relevant fields, including statistics, machine learning, economics, and political science. All this means we can guarantee world-class election forecasts on par with those put out by teams at other media outlets. Previous research by team members has included modeling and visualizations for everything from [COVID-19 infections](https://github.com/cambridge-mlg/Covid19) to [cryptocurrency price movements](https://link.springer.com/chapter/10.1007/978-3-030-65117-6_14).
+
+Contact Us 
+
+If you are interested in working with us or have any further questions, please contact paradac@carleton.edu.


### PR DESCRIPTION
@yebai What do you think?

Could we also get a short link that redirects here, like turing.ml/elect ?