### PR TITLE
Changed quick start doc to read from TuringTutorials jmd file

### DIFF
--- a/_data/toc.yml
+++ b/_data/toc.yml
@@ -1,8 +1,8 @@
 - title: "USING TURING"
-  url: "docs/using-turing/get-started"
+    url: "tutorials/docs-00-getting-started"
   children:
   - title: "Getting Started"
-    url: "docs/using-turing/get-started"
+    url: "tutorials/docs-00-getting-started"
 
   - title: "Quick Start"
     url: "docs/using-turing/quick-start"


### PR DESCRIPTION
Changing the nav bar to read the first "using tutorial" page (getting started) to read from the `TuringTutorials` repo.

Corresponds to this PR: https://github.com/TuringLang/TuringTutorials/pull/327