### PR TITLE
Update toc.yml

### DIFF
--- a/_data/toc.yml
+++ b/_data/toc.yml
@@ -1,5 +1,5 @@
 - title: "USING TURING"
-    url: "tutorials/docs-00-getting-started"
+  url: "tutorials/docs-00-getting-started"
   children:
   - title: "Getting Started"
     url: "tutorials/docs-00-getting-started"


### PR DESCRIPTION
https://github.com/TuringLang/turing.ml/pull/38 broke CI it seems. I assume the reason was the whitespace that was added in that PR.